### PR TITLE
SPA (breakout 5 pages), left nav, menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,80 +4,35 @@
     <meta charset="UTF-8">
     <title>Electron Demo</title>
     <link rel = "stylesheet" href = "./node_modules/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="import" href="sections/versions.html">
+    <link rel="import" href="sections/jqcounter.html">
+    <link rel="import" href="sections/bstable.html">
+    <link rel="import" href="sections/bstabnav.html">
+    <link rel="import" href="sections/menu.html">
   </head>
   <body>
-    <div class = "container">
-      <h1>Electron Demo</h1>
-      <!-- All of the Node.js APIs are available in this renderer process. -->
-      We are using Node.js <script>document.write(process.versions.node)</script>,<br>
-      Chromium <script>document.write(process.versions.chrome)</script>,<br>
-      and Electron <script>document.write(process.versions.electron)</script>.<br>
-      <h1>Click Counter with jQuery</h1>
-      If the counter counts up every click, then jQuery is working.<br>
-      <h3 id = "click-counter"></h3>
-      <button class = "btn btn-success" id = "countbtn">Click here</button>
-      <h1>Bootstrap - Tables - Hover Rows</h1>
-      If you hover over a line in the table below with the mouse, it should get hightlighting.  This proves that Bootstrap is working.<br>
-      <table class="table table-hover">
-        <thead>
-          <tr>
-            <th>#</th>
-            <th>First Name</th>
-            <th>Last Name</th>
-            <th>Username</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">1</th>
-            <td>Mark</td>
-            <td>Otto</td>
-            <td>@mdo</td>
-          </tr>
-          <tr>
-            <th scope="row">2</th>
-            <td>Jacob</td>
-            <td>Thornton</td>
-            <td>@fat</td>
-          </tr>
-          <tr>
-            <th scope="row">3</th>
-            <td>Larry</td>
-            <td>the Bird</td>
-            <td>@twitter</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <ul class="nav nav-tabs" id="myTab" role="tablist">
-        <li class="nav-item">
-          <a class="nav-link active" id="home-tab" data-toggle="tab" href="#home" role="tab" aria-controls="home" aria-selected="true">Home</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" id="profile-tab" data-toggle="tab" href="#profile" role="tab" aria-controls="profile" aria-selected="false">Profile</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" id="contact-tab" data-toggle="tab" href="#contact" role="tab" aria-controls="contact" aria-selected="false">Contact</a>
-        </li>
-      </ul>
-      <div class="tab-content" id="myTabContent">
-        <div class="tab-pane active" id="home" role="tabpanel" aria-labelledby="home-tab">
-          Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.
+    <section class="main">
+      <row>
+        <div class="col-sm-3">
+          <ul class="nav nav-pills nav-stacked">
+            <li><a id="versions-menu" data-section="versions" href="#">Versions</a></li>
+            <li><a id="jqcounter-menu" data-section="jqcounter" href="#">jQuery Counter</a></li>
+            <li><a id="bstable-menu" data-section="bstable" href="#">Bootstrap Table with Hover Rows</a></li>
+            <li><a id="bstabnav-menu" data-section="bstabnav" href="#">Bootstrap Tab Nav</a></li>
+            <li><a id="menu-menu" data-section="menu" href="#">Custom Menus</a></li>
+          </ul>
         </div>
-        <div class="tab-pane" id="profile" role="tabpanel" aria-labelledby="profile-tab">
-          Food truck fixie locavore, accusamus mcsweeney's marfa nulla single-origin coffee squid. Exercitation +1 labore velit, blog sartorial PBR leggings next level wes anderson artisan four loko farm-to-table craft beer twee. Qui photo booth letterpress, commodo enim craft beer mlkshk aliquip jean shorts ullamco ad vinyl cillum PBR. Homo nostrud organic, assumenda labore aesthetic magna delectus mollit. Keytar helvetica VHS salvia yr, vero magna velit sapiente labore stumptown. Vegan fanny pack odio cillum wes anderson 8-bit, sustainable jean shorts beard ut DIY ethical culpa terry richardson biodiesel. Art party scenester stumptown, tumblr butcher vero sint qui sapiente accusamus tattooed echo park.
+        <div class="col-sm-9">
+          <div id="wrapper">
+          </div>
         </div>
-        <div class="tab-pane" id="contact" role="tabpanel" aria-labelledby="contact-tab">
-          Etsy mixtape wayfarers, ethical wes anderson tofu before they sold out mcsweeney's organic lomo retro fanny pack lo-fi farm-to-table readymade. Messenger bag gentrify pitchfork tattooed craft beer, iphone skateboard locavore carles etsy salvia banksy hoodie helvetica. DIY synth PBR banksy irony. Leggings gentrify squid 8-bit cred pitchfork. Williamsburg banh mi whatever gluten-free, carles pitchfork biodiesel fixie etsy retro mlkshk vice blog. Scenester cred you probably haven't heard of them, vinyl craft beer blog stumptown. Pitchfork sustainable tofu synth chambray yr.
-        </div>
-      </div>
-
-      <script>
-        // You can also require other files to run in this process
-        window.$ = window.jQuery = require('./node_modules/jquery/dist/jquery.min.js');
-        require('./node_modules/bootstrap/dist/js/bootstrap.min.js')
-        require('./renderer.js')
-      </script>
-    </div>
+      </row>
+    </section>
+    <script>
+      // You can also require other files to run in this process
+      window.$ = window.jQuery = require('./node_modules/jquery/dist/jquery.min.js');
+      require('./node_modules/bootstrap/dist/js/bootstrap.min.js')
+      require('./renderer.js')
+    </script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -32,6 +32,8 @@ function createWindow () {
     // when you should delete the corresponding element.
     mainWindow = null
   })
+
+  require('./mainmenu')
 }
 
 // This method will be called when Electron has finished

--- a/mainmenu.js
+++ b/mainmenu.js
@@ -1,0 +1,124 @@
+const {app, Menu} = require('electron')
+
+const template = [
+  {
+    label: 'Demo',
+    submenu: [
+      {
+        label: 'Versions',
+        click (menuItem, browserWindow, event) {
+          browserWindow.webContents.send('menucall', 'versions');
+         }
+      },
+      {
+        label: 'jQuery Counter',
+        click (menuItem, browserWindow, event) {
+          browserWindow.webContents.send('menucall', 'jqcounter');
+         }
+      },
+      {
+        label: 'Bootstrap Table with Hover Rows',
+        click (menuItem, browserWindow, event) {
+          browserWindow.webContents.send('menucall', 'bstable');
+         }
+      },
+      {
+        label: 'Bootstrap Tab Nav',
+        click (menuItem, browserWindow, event) {
+          browserWindow.webContents.send('menucall', 'bstabnav');
+         }
+      },
+      {
+        label: 'Custom Menus',
+        click (menuItem, browserWindow, event) {
+          browserWindow.webContents.send('menucall', 'menu');
+         }
+      }
+    ]
+  },
+  {
+    label: 'Edit',
+    submenu: [
+      {role: 'undo'},
+      {role: 'redo'},
+      {type: 'separator'},
+      {role: 'cut'},
+      {role: 'copy'},
+      {role: 'paste'},
+      {role: 'pasteandmatchstyle'},
+      {role: 'delete'},
+      {role: 'selectall'}
+    ]
+  },
+  {
+    label: 'View',
+    submenu: [
+      {role: 'reload'},
+      {role: 'forcereload'},
+      {role: 'toggledevtools'},
+      {type: 'separator'},
+      {role: 'resetzoom'},
+      {role: 'zoomin'},
+      {role: 'zoomout'},
+      {type: 'separator'},
+      {role: 'togglefullscreen'}
+    ]
+  },
+  {
+    role: 'window',
+    submenu: [
+      {role: 'minimize'},
+      {role: 'close'}
+    ]
+  },
+  {
+    role: 'help',
+    submenu: [
+      {
+        label: 'Learn More',
+        click () { require('electron').shell.openExternal('https://electron.atom.io') }
+      }
+    ]
+  }
+]
+
+if (process.platform === 'darwin') {
+  template.unshift({
+    label: app.getName(),
+    submenu: [
+      {role: 'about'},
+      {type: 'separator'},
+      {role: 'services', submenu: []},
+      {type: 'separator'},
+      {role: 'hide'},
+      {role: 'hideothers'},
+      {role: 'unhide'},
+      {type: 'separator'},
+      {role: 'quit'}
+    ]
+  })
+
+  // Edit menu
+  template[1].submenu.push(
+    {type: 'separator'},
+    {
+      label: 'Speech',
+      submenu: [
+        {role: 'startspeaking'},
+        {role: 'stopspeaking'}
+      ]
+    }
+  )
+
+  // Window menu
+  template[3].submenu = [
+    {role: 'close'},
+    {role: 'minimize'},
+    {role: 'zoom'},
+    {type: 'separator'},
+    {role: 'front'}
+  ]
+}
+
+const menu = Menu.buildFromTemplate(template)
+Menu.setApplicationMenu(menu)

--- a/menu.js
+++ b/menu.js
@@ -1,0 +1,63 @@
+window.navigation = window.navigation || {},
+function(n) {
+  navigation.menu = {
+    constants: {
+      sectionTemplate: '.section-template',
+      contentContainer: '#wrapper',
+      startSection: '#versions'
+    },
+    importSectionsToDOM: function() {
+      const links = document.querySelectorAll('link[rel="import"]')
+      Array.prototype.forEach.call(links, function (link) {
+        let template = link.import.querySelector(navigation.menu.constants.sectionTemplate)
+        let clone = document.importNode(template.content, true)
+        document.querySelector(navigation.menu.constants.contentContainer).appendChild(clone)
+      })
+    },
+    setMenuOnClickEvent: function () {
+      document.body.addEventListener('click', function (event) {
+        if (event.target.dataset.section) {
+          navigation.menu.hideAllSections()
+          navigation.menu.showSection(event)
+        }
+      })
+    },
+    showSection: function(event) {
+      const sectionId = event.target.dataset.section
+      $('#' + sectionId).show()
+      $('#' + sectionId + ' section').show()
+    },
+    showSection2: function(sectionId) {
+      navigation.menu.hideAllSections()
+      $('#' + sectionId).show()
+      $('#' + sectionId + ' section').show()
+    },
+    showStartSection: function() {
+      navigation.menu.hideAllSections()
+      $(this.constants.startSection).show()
+      $(this.constants.startSection + ' section').show()
+    },
+    hideAllSections: function() {
+      $(this.constants.contentContainer + ' section').hide()
+    },
+    init: function() {
+      this.importSectionsToDOM()
+      this.setMenuOnClickEvent()
+      this.showStartSection()
+    }
+  };
+  n(function() {
+    navigation.menu.init()
+    let count = 0
+    $('#click-counter').text(count.toString())
+    $('#countbtn').on('click', () => {
+       count ++
+       $('#click-counter').text(count)
+    })
+    $('#myTab a').on('click', function (e) {
+      e.preventDefault()
+      $(this).tab('show')
+    })
+    $('#myTab a:first').tab('show') // Select first tab
+  })
+}(jQuery);

--- a/renderer.js
+++ b/renderer.js
@@ -1,16 +1,8 @@
 // This file is required by the index.html file and will
 // be executed in the renderer process for that window.
 // All of the Node.js APIs are available in this process.
+require('./menu')
 
-let count = 0
-$('#click-counter').text(count.toString())
-$('#countbtn').on('click', () => {
-   count ++
-   $('#click-counter').text(count)
+require('electron').ipcRenderer.on('menucall', (event, message) => {
+  window.navigation.menu.showSection2(message);
 })
-
-$('#myTab a').on('click', function (e) {
-  e.preventDefault()
-  $(this).tab('show')
-})
-$('#myTab a:first').tab('show') // Select first tab

--- a/sections/bstable.html
+++ b/sections/bstable.html
@@ -1,0 +1,36 @@
+<template class="section-template">
+  <section id="bstable">
+    <h1>Bootstrap - Tables - Hover Rows</h1>
+    If you hover over a line in the table below with the mouse, it should get hightlighting.  This proves that Bootstrap is working.<br>
+    <table class="table table-hover">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Username</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">1</th>
+          <td>Mark</td>
+          <td>Otto</td>
+          <td>@mdo</td>
+        </tr>
+        <tr>
+          <th scope="row">2</th>
+          <td>Jacob</td>
+          <td>Thornton</td>
+          <td>@fat</td>
+        </tr>
+        <tr>
+          <th scope="row">3</th>
+          <td>Larry</td>
+          <td>the Bird</td>
+          <td>@twitter</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</template>

--- a/sections/bstabnav.html
+++ b/sections/bstabnav.html
@@ -1,0 +1,28 @@
+<template class="section-template">
+  <section id="bstabnav" class="wrapper style1">
+    <h1>Bootstrap - Tab Navs</h1>
+    You should get 3 tabs with fake content.<br>
+    <ul class="nav nav-tabs" id="myTab" role="tablist">
+      <li class="nav-item">
+        <a class="nav-link active" id="home-tab" data-toggle="tab" href="#home" role="tab" aria-controls="home" aria-selected="true">Home</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" id="profile-tab" data-toggle="tab" href="#profile" role="tab" aria-controls="profile" aria-selected="false">Profile</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" id="contact-tab" data-toggle="tab" href="#contact" role="tab" aria-controls="contact" aria-selected="false">Contact</a>
+      </li>
+    </ul>
+    <div class="tab-content" id="myTabContent">
+      <div class="tab-pane active" id="home" role="tabpanel" aria-labelledby="home-tab">
+        Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.
+      </div>
+      <div class="tab-pane" id="profile" role="tabpanel" aria-labelledby="profile-tab">
+        Food truck fixie locavore, accusamus mcsweeney's marfa nulla single-origin coffee squid. Exercitation +1 labore velit, blog sartorial PBR leggings next level wes anderson artisan four loko farm-to-table craft beer twee. Qui photo booth letterpress, commodo enim craft beer mlkshk aliquip jean shorts ullamco ad vinyl cillum PBR. Homo nostrud organic, assumenda labore aesthetic magna delectus mollit. Keytar helvetica VHS salvia yr, vero magna velit sapiente labore stumptown. Vegan fanny pack odio cillum wes anderson 8-bit, sustainable jean shorts beard ut DIY ethical culpa terry richardson biodiesel. Art party scenester stumptown, tumblr butcher vero sint qui sapiente accusamus tattooed echo park.
+      </div>
+      <div class="tab-pane" id="contact" role="tabpanel" aria-labelledby="contact-tab">
+        Etsy mixtape wayfarers, ethical wes anderson tofu before they sold out mcsweeney's organic lomo retro fanny pack lo-fi farm-to-table readymade. Messenger bag gentrify pitchfork tattooed craft beer, iphone skateboard locavore carles etsy salvia banksy hoodie helvetica. DIY synth PBR banksy irony. Leggings gentrify squid 8-bit cred pitchfork. Williamsburg banh mi whatever gluten-free, carles pitchfork biodiesel fixie etsy retro mlkshk vice blog. Scenester cred you probably haven't heard of them, vinyl craft beer blog stumptown. Pitchfork sustainable tofu synth chambray yr.
+      </div>
+    </div>
+  </section>
+</template>

--- a/sections/jqcounter.html
+++ b/sections/jqcounter.html
@@ -1,0 +1,8 @@
+<template class="section-template">
+  <section id="jqcounter">
+    <h1>Click Counter with jQuery</h1>
+    If the counter counts up every click, then jQuery is working.<br>
+    <h3 id = "click-counter"></h3>
+    <button class = "btn btn-success" id = "countbtn">Click here</button>
+  </section>
+</template>

--- a/sections/menu.html
+++ b/sections/menu.html
@@ -1,0 +1,15 @@
+<template class="section-template">
+  <section id="menu">
+    <h1>Menu</h1>
+    The Demo menu at the top left simply replicates the left nav links.<br>
+    <br>
+    Custom menus are easy to create using menu templates.<br>
+    However, unlike most electron functionality, there are platform differences<br>
+    that need to be considered between Mac, Win and Linux.<br>
+    <br>
+    Another tricky part is communications between the menu in the main process<br>
+    down to the pages in the renderer process.<br>
+    The Demo menu item uses webContents() to send events to the index.html renderer,<br>
+    which in turn activates the appropriate page/content.
+  </section>
+</template>

--- a/sections/versions.html
+++ b/sections/versions.html
@@ -1,0 +1,16 @@
+<template class="section-template">
+  <section id="versions">
+    <h1>Electron Demo</h1>
+    We are using Node.js
+    <span id="node_version"></span>,<br>
+    Chromium
+    <span id="chrome_version"></span>,<br>
+    and Electron
+    <span id="electron_version"></span>.<br>
+    <script>
+      document.getElementById('node_version').innerHTML = process.versions.node;
+      document.getElementById('chrome_version').innerHTML = process.versions.chrome;
+      document.getElementById('electron_version').innerHTML = process.versions.electron;
+    </script>
+  </section>
+</template>


### PR DESCRIPTION
Add leftnav.
Built menu template in mainmenu.js.
SPA design
- breakout each page to its own section: see sections folder
- renderer.js calls menu.js
- menu.js handles navigation from left nav and menu
- page specific js moved to menu.js (which runs after page sections are loaded)
For each new section
- create file in sections folder
- add import to index.html <head>
- add left nav anchor in index.html
- add menu item in mainmenu.js

On branch menus
Changes to be committed:
	modified:   index.html
	modified:   main.js
	new file:   mainmenu.js
	new file:   menu.js
	modified:   renderer.js
	new file:   sections/bstable.html
	new file:   sections/bstabnav.html
	new file:   sections/jqcounter.html
	new file:   sections/menu.html
	new file:   sections/versions.html